### PR TITLE
Reference correct ES6 module output in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=10.0.0"
   },
   "main": "./dist/pngjs3.js",
-  "module": "./dist/pngjs3.es.js",
+  "module": "./dist/pngjs3.es6.js",
   "types": "./dist/index.d.ts",
   "directories": {
     "lib": "dist",


### PR DESCRIPTION
The file produced by the build is `./dist/pngjs3.es6.js`, but package.json references `./dist/pngjs3.es.js`, which does not exist.